### PR TITLE
groomer info now displays hours of operation

### DIFF
--- a/src/components/pages/GroomerDashboard/groomer-tabs.js
+++ b/src/components/pages/GroomerDashboard/groomer-tabs.js
@@ -1,8 +1,7 @@
-import { Tabs, Row } from 'antd';
+import { Tabs } from 'antd';
 import React from 'react';
 import Overview from './overview';
 import GroomerProfilePage from '../GroomerProfile/GroomerProfilePage';
-import { ProfileFormGR } from '../ProfileFormGR';
 
 const { TabPane } = Tabs;
 

--- a/src/components/pages/GroomerDashboard/groomer-tabs.js
+++ b/src/components/pages/GroomerDashboard/groomer-tabs.js
@@ -3,8 +3,9 @@ import { Alert, Col, Form, Row, Tabs } from 'antd';
 import Overview from './overview';
 import GroomerProfilePage from '../GroomerProfile/GroomerProfilePage';
 import RenderFormGR from '../ProfileFormGR/RenderFormGR';
-import { FormContext } from '../../../state/contexts/FormContext';
 import './groomer-dash.scss';
+// context imports below
+import { FormContext } from '../../../state/contexts/FormContext';
 
 const { TabPane } = Tabs;
 

--- a/src/components/pages/GroomerProfile/GroomerProfilePage.js
+++ b/src/components/pages/GroomerProfile/GroomerProfilePage.js
@@ -5,7 +5,7 @@ import { UserOutlined } from '@ant-design/icons';
 import 'antd/dist/antd.css';
 import './groomer.css';
 import Services from './ServicesArea';
-// context imports
+// context imports below
 import { APIContext } from '../../../state/contexts/APIContext';
 import { UsersContext } from '../../../state/contexts/UsersContext';
 import { GroomersContext } from '../../../state/contexts/GroomersContext';

--- a/src/components/pages/GroomerProfile/GroomerProfilePage.js
+++ b/src/components/pages/GroomerProfile/GroomerProfilePage.js
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { ProfileFormGR } from '../ProfileFormGR';
-import { Layout, Avatar, Divider } from 'antd';
+import { Avatar, Divider, Layout } from 'antd';
 import { UserOutlined } from '@ant-design/icons';
 import 'antd/dist/antd.css';
 import './groomer.css';
@@ -10,12 +10,26 @@ import { UsersContext } from '../../../state/contexts/UsersContext';
 import { GroomersContext } from '../../../state/contexts/GroomersContext';
 import { FormContext } from '../../../state/contexts/FormContext';
 import RenderFormGR from '../ProfileFormGR/RenderFormGR';
+import { APIContext } from '../../../state/contexts/APIContext';
 
 const GroomerProfilePage = () => {
   // context state
   const { userInfo } = useContext(UsersContext);
-  const { groomerInfo } = useContext(GroomersContext);
+  const { groomerInfo, setHours, hours } = useContext(GroomersContext);
   const { showForm } = useContext(FormContext);
+  const { getLoggedInGroomer } = useContext(APIContext);
+
+  useEffect(() => {
+    getLoggedInGroomer();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (groomerInfo.hours) {
+      setHours(JSON.parse(groomerInfo.hours));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groomerInfo]);
 
   return (
     <div>
@@ -98,6 +112,55 @@ const GroomerProfilePage = () => {
                 {groomerInfo.country
                   ? groomerInfo.country
                   : 'Update your profile'}
+              </p>
+            </div>
+          </div>
+          <div className="panel">
+            <Divider style={{ borderColor: 'lightblue' }}>
+              Hours of Operation
+            </Divider>
+            <div className="panel-info">
+              <p>
+                Monday:{' '}
+                {hours.monday.open
+                  ? `${hours.monday.open} - ${hours.monday.close}`
+                  : hours.monday}
+              </p>
+              <p>
+                Tuesday:{' '}
+                {hours.tuesday.open
+                  ? `${hours.tuesday.open} - ${hours.tuesday.close}`
+                  : hours.tuesday}
+              </p>
+              <p>
+                Wednesday:{' '}
+                {hours.wednesday.open
+                  ? `${hours.wednesday.open} - ${hours.wednesday.close}`
+                  : hours.wednesday}
+              </p>
+              <p>
+                Thursday:{' '}
+                {hours.thursday.open
+                  ? `${hours.thursday.open} - ${hours.thursday.close}`
+                  : hours.thursday}
+              </p>
+              <p>
+                Friday:{' '}
+                {hours.friday.open
+                  ? `${hours.friday.open} - ${hours.friday.close}`
+                  : hours.friday}
+              </p>
+              <p>
+                Saturday:{' '}
+                {hours.saturday.open
+                  ? `${hours.saturday.open} - ${hours.saturday.close}`
+                  : hours.saturday}
+              </p>
+              <p>
+                Sunday:{' '}
+                {hours.sunday.open
+                  ? `${hours.sunday.open} - ${hours.sunday.close}`
+                  : hours.sunday}
               </p>
             </div>
           </div>

--- a/src/components/pages/GroomerProfile/groomer.css
+++ b/src/components/pages/GroomerProfile/groomer.css
@@ -14,7 +14,6 @@
 
 .customer-info-box {
     display: flex;
-
 }
 
 .panel {
@@ -23,5 +22,5 @@
 }
 
 .panel-info {
-    padding: 0px 30%;
+    /*padding: 0px 30%;*/
 }

--- a/src/components/pages/ProfileFormGR/FormGRContainer.js
+++ b/src/components/pages/ProfileFormGR/FormGRContainer.js
@@ -27,7 +27,6 @@ const FormGRContainer = () => {
 
   useEffect(() => {
     if (groomerInfo.hours) {
-      // setHoursOfOpp(JSON.parse(groomerInfo.hours));
       setHours(JSON.parse(groomerInfo.hours));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/state/contexts/GroomersContext.js
+++ b/src/state/contexts/GroomersContext.js
@@ -32,7 +32,6 @@ const GroomersProvider = ({ children }) => {
     friday: 'closed',
     saturday: 'closed',
   };
-  const [hoursOfOpp, setHoursOfOpp] = useState(hoursTemp);
   const [hours, setHours] = useState(hoursTemp);
 
   //services
@@ -168,10 +167,8 @@ const GroomersProvider = ({ children }) => {
         groomerServices,
         setGroomerServices,
         hours,
-        hoursOfOpp,
         hoursTemp,
         setHours,
-        setHoursOfOpp,
         services,
         setServices,
         serviceToAdd,


### PR DESCRIPTION
## Description ##

The hours of operation are now displayed in the groomer info panel of the groomer dashboard
- we may want to consider restyling this to allow more room for the items.


## Type ##

- [ ] This is a bugfix.
- [x] This is a new feature.
- [ ] This is part of a feature.

## Organization ##

- [ ] Have you linked this pull request to a Trello card?
- [x] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing 

## Review ##

- [ ] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added two reviewers to this pull request?
