### PR TITLE
fix(forms) pet and customer forms mixing 

### DIFF
--- a/src/components/pages/PetForm/PetFormModal.js
+++ b/src/components/pages/PetForm/PetFormModal.js
@@ -9,8 +9,8 @@ const PetFormModal = () => {
 
   // context state
   const {
-    visible,
-    setVisible,
+    petFormVisible,
+    setPetFormVisible,
     loading,
     setLoading,
     onPetFormFinishFailed,
@@ -22,11 +22,11 @@ const PetFormModal = () => {
   // modal specific functions
   const showModal = () => {
     setLoading(false);
-    setVisible(true);
+    setPetFormVisible(true);
   };
 
   const handleCancel = () => {
-    setVisible(false);
+    setPetFormVisible(false);
   };
 
   // this function will be used to handle pet form submit
@@ -34,7 +34,7 @@ const PetFormModal = () => {
     setLoading(true);
     await addNewPet(authState, values);
     await setTimeout(() => {
-      setVisible(false);
+      setPetFormVisible(false);
     }, 2000);
   };
 
@@ -46,7 +46,7 @@ const PetFormModal = () => {
       <Modal
         okButtonProps={{ form: 'pet-form', key: 'submit', htmlType: 'submit' }}
         title="Pet Information"
-        visible={visible}
+        visible={petFormVisible}
         confirmLoading={loading}
         onCancel={handleCancel}
       >

--- a/src/components/pages/ProfileFormPO/RenderFormPO.js
+++ b/src/components/pages/ProfileFormPO/RenderFormPO.js
@@ -20,8 +20,8 @@ const RenderFormPO = () => {
     onFailed,
     showDelete,
     setShowDelete,
-    visible,
-    setVisible,
+    custFormVisible,
+    setCustFormVisible,
     loading,
     setLoading,
   } = useContext(FormContext);
@@ -58,7 +58,7 @@ const RenderFormPO = () => {
     }
     setUpdated(!updated);
     await setTimeout(() => {
-      setVisible(false);
+      setCustFormVisible(false);
     }, 2000);
   };
 
@@ -66,11 +66,11 @@ const RenderFormPO = () => {
   const showModal = () => {
     getCustomerByID(authState);
     setLoading(false);
-    setVisible(true);
+    setCustFormVisible(true);
   };
 
   const handleCancel = () => {
-    setVisible(false);
+    setCustFormVisible(false);
   };
 
   return (
@@ -85,7 +85,7 @@ const RenderFormPO = () => {
           htmlType: 'submit',
         }}
         title="Customer Information"
-        visible={visible}
+        visible={custFormVisible}
         confirmLoading={loading}
         onCancel={handleCancel}
       >

--- a/src/state/contexts/FormContext.js
+++ b/src/state/contexts/FormContext.js
@@ -10,7 +10,8 @@ const FormProvider = ({ children }) => {
   const [searchValue, setSearchValue] = useState('');
   const [loading, setLoading] = useState(false);
   const [value, setValue] = useState(false);
-  const [visible, setVisible] = useState(false);
+  const [petFormVisible, setPetFormVisible] = useState(false);
+  const [custFormVisible, setCustFormVisible] = useState(false);
   //for result message on submitting form
   const [resultInfo, setResultInfo] = useState({ message: null, type: null });
   //for delete modal
@@ -52,9 +53,11 @@ const FormProvider = ({ children }) => {
         setSearchValue,
         loading,
         setLoading,
-        visible,
-        setVisible,
         value,
+        petFormVisible,
+        setPetFormVisible,
+        custFormVisible,
+        setCustFormVisible,
         toggleForm,
         onFailed,
         onPetFormFinishFailed,


### PR DESCRIPTION
## Description ##
 
Resolved the issue where switching back to pet form after customer form would render the customer form on when clicking the button to display the pet form.  I handled this by giving them each different visible states rather than using a generic visible state.

## Type ##

- [x] This is a bugfix.
- [ ] This is a new feature.
- [ ] This is part of a feature.

## Organization ##

- [x] Have you linked this pull request to a Trello card?
- [x] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing 

## Review ##

- [ ] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added two reviewers to this pull request?
